### PR TITLE
parse_requirements changed in pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 import uuid
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
-
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 


### PR DESCRIPTION
due to an change within pip, the original setup.py would fail with ```ModuleNotFoundError: No module named 'pip.req'```